### PR TITLE
Substitutions in quotes

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
@@ -38,7 +38,7 @@ final class Tokenizer {
             return "tab";
         else if (codepoint == -1)
             return "end of file";
-        else if (Character.isISOControl(codepoint))
+        else if (ConfigImplUtil.isC0Control(codepoint))
             return String.format("control character 0x%x", codepoint);
         else
             return String.format("%c", codepoint);
@@ -424,9 +424,6 @@ final class Tokenizer {
             case 't':
                 sb.append('\t');
                 break;
-            case '$':
-                sb.append("\\$");
-                break;
             case 'u': {
                 // kind of absurdly slow, but screw it for now
                 char[] a = new char[4];
@@ -537,7 +534,7 @@ final class Tokenizer {
                     // Reset and continue
                     sb = new StringBuilder();
                     sbOrig = new StringBuilder();
-                } else if (Character.isISOControl(c)) {
+                } else if (ConfigImplUtil.isC0Control(c)) {
                     throw problem(asString(c), "JSON does not allow unescaped " + asString(c)
                             + " in quoted strings, use a backslash escape");
                 } else {

--- a/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
@@ -38,7 +38,7 @@ final class Tokenizer {
             return "tab";
         else if (codepoint == -1)
             return "end of file";
-        else if (ConfigImplUtil.isC0Control(codepoint))
+        else if (Character.isISOControl(codepoint))
             return String.format("control character 0x%x", codepoint);
         else
             return String.format("%c", codepoint);
@@ -170,6 +170,12 @@ final class Tokenizer {
                         "bug: putBack() three times, undesirable look-ahead");
             }
             buffer.push(c);
+        }
+
+        private int peekNextCharRaw() {
+            int c = nextCharRaw();
+            putBack(c);
+            return c;
         }
 
         static boolean isWhitespace(int c) {
@@ -418,6 +424,9 @@ final class Tokenizer {
             case 't':
                 sb.append('\t');
                 break;
+            case '$':
+                sb.append("\\$");
+                break;
             case 'u': {
                 // kind of absurdly slow, but screw it for now
                 char[] a = new char[4];
@@ -477,7 +486,9 @@ final class Tokenizer {
             }
         }
 
-        private Token pullQuotedString() throws ProblemException {
+        private List<Token> pullQuotedString() throws ProblemException {
+            List<Token> tokens = new ArrayList<Token>();
+
             // the open quote has already been consumed
             StringBuilder sb = new StringBuilder();
 
@@ -488,6 +499,23 @@ final class Tokenizer {
             StringBuilder sbOrig = new StringBuilder();
             sbOrig.appendCodePoint('"');
 
+            // First, check for triple quotes
+            if (peekNextCharRaw() == '"') { // Double quotes
+                int second = nextCharRaw();
+                if (peekNextCharRaw() == '"') { // Triple quotes! Append and return token
+                    int third = nextCharRaw();
+                    sbOrig.appendCodePoint(second);
+                    sbOrig.appendCodePoint(third);
+                    appendTripleQuotedString(sb, sbOrig);
+
+                    tokens.add(Tokens.newString(lineOrigin, sb.toString(), sbOrig.toString()));
+                    return tokens;
+                } else { // Empty string, handled by normal string termination case below
+                    putBack(second);
+                }
+            }
+
+            // Single quoted string with possible substitutions
             while (true) {
                 int c = nextCharRaw();
                 if (c == -1)
@@ -497,8 +525,19 @@ final class Tokenizer {
                     pullEscapeSequence(sb, sbOrig);
                 } else if (c == '"') {
                     sbOrig.appendCodePoint(c);
+                    tokens.add(Tokens.newString(lineOrigin, sb.toString(), sbOrig.toString()));
                     break;
-                } else if (ConfigImplUtil.isC0Control(c)) {
+                } else if (c == '$' && peekNextCharRaw() == '{') { // Substition
+                    // Tokenize what we have so far
+                    tokens.add(Tokens.newString(lineOrigin, sb.toString(), sbOrig.toString()));
+
+                    // Add substition
+                    tokens.add(pullSubstitution());
+
+                    // Reset and continue
+                    sb = new StringBuilder();
+                    sbOrig = new StringBuilder();
+                } else if (Character.isISOControl(c)) {
                     throw problem(asString(c), "JSON does not allow unescaped " + asString(c)
                             + " in quoted strings, use a backslash escape");
                 } else {
@@ -507,18 +546,7 @@ final class Tokenizer {
                 }
             }
 
-            // maybe switch to triple-quoted string, sort of hacky...
-            if (sb.length() == 0) {
-                int third = nextCharRaw();
-                if (third == '"') {
-                    sbOrig.appendCodePoint(third);
-                    appendTripleQuotedString(sb, sbOrig);
-                } else {
-                    putBack(third);
-                }
-
-            }
-            return Tokens.newString(lineOrigin, sb.toString(), sbOrig.toString());
+            return tokens;
         }
 
         private Token pullPlusEquals() throws ProblemException {
@@ -575,7 +603,17 @@ final class Tokenizer {
             return Tokens.newSubstitution(origin, optional, expression);
         }
 
+        // Occasionally pullNextToken will encounter a situation where it needs to
+        // parse multiple tokens. When that happens it will populate this queue and pop
+        // from it until empty before attempting to parse a new token.
+        // Substitutions within quoted strings are an example of this.
+        private static Queue<Token> nextTokensQueue = new LinkedList<Token>();
+
         private Token pullNextToken(WhitespaceSaver saver) throws ProblemException {
+            if (!nextTokensQueue.isEmpty()) {
+                return nextTokensQueue.remove();
+            }
+
             int c = nextCharAfterWhitespace(saver);
             if (c == -1) {
                 return Tokens.END;
@@ -592,7 +630,11 @@ final class Tokenizer {
                 } else {
                     switch (c) {
                     case '"':
-                        t = pullQuotedString();
+                        List<Token> all = pullQuotedString();
+                        t = all.remove(0);
+                        for (Token n: all) {
+                            nextTokensQueue.add(n);
+                        }
                         break;
                     case '$':
                         t = pullSubstitution();

--- a/config/src/test/resources/beanconfig/beanconfig01.conf
+++ b/config/src/test/resources/beanconfig/beanconfig01.conf
@@ -52,7 +52,17 @@
         "ofConfigObject" : [${numbers}, ${booleans}, ${strings}],
         "ofConfigValue" : [1, 2, "a"],
         "ofDuration" : [1, 2h, 3 days],
-        "ofMemorySize" : [1024, 1M, 1G]
+        "ofMemorySize" : [1024, 1M, 1G],
+        "ofStringBean" : [
+                {
+                        abcd : "testAbcdOne"
+                        yes : "testYesOne"
+                },
+                {
+                        abcd : "testAbcdTwo"
+                        yes : "testYesTwo"
+                }
+        ]
     },
     "bytes" : {
         "kilobyte" : "1kB",

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
@@ -40,6 +40,7 @@ class ConfigSubstitutionTest extends TestUtils {
        "bool" : true,
        "null" : null,
        "string" : "hello",
+       "stringwsub": "hello ${foo} bar",
        "double" : 3.14
     }
 }
@@ -86,6 +87,13 @@ class ConfigSubstitutionTest extends TestUtils {
         val s = subst("bar.string")
         val v = resolveWithoutFallbacks(s, simpleObject)
         assertEquals(stringValue("hello"), v)
+    }
+
+    @Test
+    def resolveStringWSub() {
+        val s = subst("bar.stringwsub")
+        val v = resolveWithoutFallbacks(s, simpleObject)
+        assertEquals(stringValue("hello 42 bar"), v)
     }
 
     @Test

--- a/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
@@ -153,6 +153,31 @@ class TokenizerTest extends TestUtils {
     }
 
     @Test
+    def tokenizeSubstitutionsInQuoted() {
+        val source = "\"foo${bar}baz\"\n"
+        val expected = List(tokenString("foo"), tokenSubstitution(tokenUnquoted("bar")),
+            tokenString("baz"),
+            tokenLine(1))
+        tokenizerTest(expected, source)
+    }
+
+    @Test
+    def tokenizeSubstitutionsInQuotedAtBeg() {
+        val source = "\"${bar}baz\"\n"
+        val expected = List(tokenString(""), tokenSubstitution(tokenUnquoted("bar")),
+            tokenString("baz"),
+            tokenLine(1))
+        tokenizerTest(expected, source)
+    }
+
+    @Test
+    def tokenizeSubstitutionsInQuotedAtEnd() {
+        val source = "\"foo${bar}\""
+        val expected = List(tokenString("foo"), tokenSubstitution(tokenUnquoted("bar")), tokenString(""))
+        tokenizerTest(expected, source)
+    }
+
+    @Test
     def tokenizerUnescapeStrings(): Unit = {
         case class UnescapeTest(escaped: String, result: ConfigString)
         implicit def pair2unescapetest(pair: (String, String)): UnescapeTest = UnescapeTest(pair._1, new ConfigString.Quoted(fakeOrigin(), pair._2))

--- a/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
@@ -57,8 +57,6 @@ class UtilTest extends TestUtils {
         assertTrue(ConfigImplUtil.equalsHandlingNull("", ""))
     }
 
-    val lotsOfStrings = (invalidJson ++ validConf).map(_.test)
-
     private def roundtripJson(s: String) {
         val rendered = ConfigImplUtil.renderJsonString(s)
         val parsed = parseConfig("{ foo: " + rendered + "}").getString("foo")
@@ -76,6 +74,11 @@ class UtilTest extends TestUtils {
             " parsed '" + parsed + "' " + parsed.length,
             s == parsed)
     }
+
+    // These strings are used in many different ways, but for testing how things
+    // render we don't want to have any substitutions because this render code
+    // does not resolve the configs.
+    val lotsOfStrings = (invalidJson ++ validConf).map(_.test).filter(_.indexOf("${") == -1)
 
     @Test
     def renderJsonString() {


### PR DESCRIPTION
This allows for substitutions within single quoted strings.  Am very open to other ways of doing this.  Basically what I had to do was modify the "next token" logic to conditionally generate more than one token, and then queueing up any extras to be used before parsing any more.
