### PR TITLE
Conditionals

### DIFF
--- a/HOCON.md
+++ b/HOCON.md
@@ -22,6 +22,7 @@
       - [Note: Arrays without commas or newlines](#note-arrays-without-commas-or-newlines)
     - [Path expressions](#path-expressions)
     - [Paths as keys](#paths-as-keys)
+    - [Conditional expressions](#conditional-expressions)
     - [Substitutions](#substitutions)
       - [Self-Referential Substitutions](#self-referential-substitutions)
       - [The `+=` field separator](#the--field-separator)
@@ -718,6 +719,23 @@ Cycles should be treated the same as a missing value when
 resolving an optional substitution (i.e. the `${?foo}` syntax).
 If `${?foo}` refers to itself then it's as if it referred to a
 nonexistent value.
+
+### Conditional expressions
+
+Conditional expressions allow for a block of configuration to be
+included or omitted based on the value of a substitution.
+
+Example conditional expression:
+
+  - `if [${a} == "a"] { b: true }`
+
+In this case, if the substitution ${a} was equal to the string "a"
+then the object { b: true } would be merged into the object that
+the conditional expression was declared inside. If it was not
+equal to "a" nothing would be merged.
+
+The left hand side substitution cannot be optional. Currently, only equality comparisons are supported. The right hand side
+of the expression can be any string, quoted or unquoted, or a boolean.
 
 #### The `+=` field separator
 

--- a/HOCON.md
+++ b/HOCON.md
@@ -22,11 +22,11 @@
       - [Note: Arrays without commas or newlines](#note-arrays-without-commas-or-newlines)
     - [Path expressions](#path-expressions)
     - [Paths as keys](#paths-as-keys)
-    - [Conditional expressions](#conditional-expressions)
     - [Substitutions](#substitutions)
       - [Self-Referential Substitutions](#self-referential-substitutions)
       - [The `+=` field separator](#the--field-separator)
       - [Examples of Self-Referential Substitutions](#examples-of-self-referential-substitutions)
+    - [Conditional expressions](#conditional-expressions)
     - [Includes](#includes)
       - [Include syntax](#include-syntax)
       - [Include semantics: merging](#include-semantics-merging)
@@ -720,23 +720,6 @@ resolving an optional substitution (i.e. the `${?foo}` syntax).
 If `${?foo}` refers to itself then it's as if it referred to a
 nonexistent value.
 
-### Conditional expressions
-
-Conditional expressions allow for a block of configuration to be
-included or omitted based on the value of a substitution.
-
-Example conditional expression:
-
-  - `if [${a} == "a"] { b: true }`
-
-In this case, if the substitution ${a} was equal to the string "a"
-then the object { b: true } would be merged into the object that
-the conditional expression was declared inside. If it was not
-equal to "a" nothing would be merged.
-
-The left hand side substitution cannot be optional. Currently, only equality comparisons are supported. The right hand side
-of the expression can be any string, quoted or unquoted, or a boolean.
-
 #### The `+=` field separator
 
 Fields may have `+=` as a separator rather than `:` or `=`. A
@@ -912,6 +895,23 @@ retained). Memoization should be keyed by the substitution
 rather than by the path inside the `${}` expression, because
 substitutions may be resolved differently depending on their
 position in the file.
+
+### Conditional expressions
+
+Conditional expressions allow for a block of configuration to be
+included or omitted based on the value of a substitution.
+
+Example conditional expression:
+
+  - `if [${a} == "a"] { b: true }`
+
+In this case, if the substitution ${a} was equal to the string "a"
+then the object { b: true } would be merged into the object that
+the conditional expression was declared inside. If it was not
+equal to "a" nothing would be merged.
+
+The left hand side substitution cannot be optional. Currently, only equality comparisons are supported. The right hand side
+of the expression can be any string, quoted or unquoted, or a boolean.
 
 ### Includes
 

--- a/config/src/main/java/com/typesafe/config/impl/ConfigConditional.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigConditional.java
@@ -20,15 +20,17 @@ public class ConfigConditional {
         }
     }
 
-    public SimpleConfigObject resolve(Map<String, AbstractConfigValue> values) {
-        AbstractConfigValue val = values.get(left.path().first());
-        if (val == null) {
-            throw new ConfigException.BugOrBroken("Could not resolve substitution " + this.left.toString() + " in conditional expression");
-        }
-        if (val.equals(this.right)) {
-            return this.body;
-        } else {
-            return null;
+    public SimpleConfigObject resolve(ResolveContext context, ResolveSource source) {
+        try {
+            AbstractConfigValue val = source.lookupSubst(context, this.left, 0).result.value;
+
+            if (val.equals(this.right)) {
+                return this.body;
+            } else {
+                return SimpleConfigObject.empty();
+            }
+        } catch (AbstractConfigValue.NotPossibleToResolve e){
+            throw new ConfigException.BugOrBroken("Could not resolve left side of conditional expression: " + this.left.toString());
         }
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigConditional.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigConditional.java
@@ -1,0 +1,34 @@
+package com.typesafe.config.impl;
+
+import com.typesafe.config.ConfigException;
+
+import java.util.Map;
+
+public class ConfigConditional {
+
+    private SubstitutionExpression left;
+    private AbstractConfigValue right;
+    private SimpleConfigObject body;
+
+    ConfigConditional(SubstitutionExpression left, AbstractConfigValue right, SimpleConfigObject body) {
+        this.left = left;
+        this.right = right;
+        this.body = body;
+
+        if (this.left.optional()) {
+            throw new ConfigException.BugOrBroken("Substitutions in conditional expressions cannot be optional");
+        }
+    }
+
+    public SimpleConfigObject resolve(Map<String, AbstractConfigValue> values) {
+        AbstractConfigValue val = values.get(left.path().first());
+        if (val == null) {
+            throw new ConfigException.BugOrBroken("Could not resolve substitution " + this.left.toString() + " in conditional expression");
+        }
+        if (val.equals(this.right)) {
+            return this.body;
+        } else {
+            return null;
+        }
+    }
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigConditional.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigConditional.java
@@ -16,7 +16,7 @@ public class ConfigConditional {
         this.body = body;
 
         if (this.left.optional()) {
-            throw new ConfigException.BugOrBroken("Substitutions in conditional expressions cannot be optional");
+            throw new ConfigException.BugOrBroken("Substitution " + this.left.toString() + " in conditional expression cannot be optional");
         }
     }
 

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeConditional.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeConditional.java
@@ -28,14 +28,5 @@ final class ConfigNodeConditional extends AbstractConfigNode {
         }
         return tokens;
     }
-//
-//    protected String name() {
-//        for (AbstractConfigNode n : children) {
-//            if (n instanceof ConfigNodeSimpleValue) {
-//                return (String)Tokens.getValue(((ConfigNodeSimpleValue) n).token()).unwrapped();
-//            }
-//        }
-//        return null;
-//    }
 }
 

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeConditional.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeConditional.java
@@ -1,0 +1,41 @@
+package com.typesafe.config.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+final class ConfigNodeConditional extends AbstractConfigNode {
+    final private ArrayList<AbstractConfigNode> children;
+    final private AbstractConfigNodeValue body;
+
+    ConfigNodeConditional(Collection<AbstractConfigNode> children, AbstractConfigNodeValue body) {
+        this.children = new ArrayList<AbstractConfigNode>(children);
+        this.body = body;
+
+    }
+
+    public AbstractConfigNodeValue body() { return body; }
+    public List<AbstractConfigNode> children() { return children; }
+
+    @Override
+    protected Collection<Token> tokens() {
+        ArrayList<Token> tokens = new ArrayList<Token>();
+        for (AbstractConfigNode child : children) {
+            tokens.addAll(child.tokens());
+        }
+        for (Token token : body.tokens()) {
+            tokens.add(token);
+        }
+        return tokens;
+    }
+//
+//    protected String name() {
+//        for (AbstractConfigNode n : children) {
+//            if (n instanceof ConfigNodeSimpleValue) {
+//                return (String)Tokens.getValue(((ConfigNodeSimpleValue) n).token()).unwrapped();
+//            }
+//        }
+//        return null;
+//    }
+}
+

--- a/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
@@ -338,7 +338,7 @@ final class ConfigParser {
                 }
             }
 
-            return new SimpleConfigObject(objectOrigin, values);
+            return new SimpleConfigObject(objectOrigin, values, conditionals);
         }
 
         private SimpleConfigList parseArray(ConfigNodeArray n) {

--- a/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
@@ -94,7 +94,7 @@ final class ConfigParser {
             } else if (n instanceof ConfigNodeObject) {
                 v = parseObject((ConfigNodeObject)n);
             } else if (n instanceof ConfigNodeArray) {
-                v = parseArray((ConfigNodeArray) n);
+                v = parseArray((ConfigNodeArray)n);
             } else if (n instanceof ConfigNodeConcatenation) {
                 v = parseConcatenation((ConfigNodeConcatenation)n);
             } else {

--- a/config/src/main/java/com/typesafe/config/impl/ResolveStatus.java
+++ b/config/src/main/java/com/typesafe/config/impl/ResolveStatus.java
@@ -12,11 +12,13 @@ enum ResolveStatus {
     UNRESOLVED, RESOLVED;
 
     final static ResolveStatus fromValues(
-            Collection<? extends AbstractConfigValue> values) {
+            Collection<? extends AbstractConfigValue> values, Collection<ConfigConditional> conditionals) {
         for (AbstractConfigValue v : values) {
             if (v.resolveStatus() == ResolveStatus.UNRESOLVED)
                 return ResolveStatus.UNRESOLVED;
         }
+        if (conditionals.size() > 0)
+            return ResolveStatus.UNRESOLVED;
         return ResolveStatus.RESOLVED;
     }
 

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigList.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigList.java
@@ -26,8 +26,7 @@ final class SimpleConfigList extends AbstractConfigValue implements ConfigList, 
     final private boolean resolved;
 
     SimpleConfigList(ConfigOrigin origin, List<AbstractConfigValue> value) {
-        this(origin, value, ResolveStatus
-                .fromValues(value));
+        this(origin, value, ResolveStatus.fromValues(value, new ArrayList<ConfigConditional>()));
     }
 
     SimpleConfigList(ConfigOrigin origin, List<AbstractConfigValue> value,
@@ -37,7 +36,7 @@ final class SimpleConfigList extends AbstractConfigValue implements ConfigList, 
         this.resolved = status == ResolveStatus.RESOLVED;
 
         // kind of an expensive debug check (makes this constructor pointless)
-        if (status != ResolveStatus.fromValues(value))
+        if (status != ResolveStatus.fromValues(value, new ArrayList<ConfigConditional>()))
             throw new ConfigException.BugOrBroken(
                     "SimpleConfigList created with wrong resolve status: " + this);
     }

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -28,12 +28,15 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
 
     // this map should never be modified - assume immutable
     final private Map<String, AbstractConfigValue> value;
+    final private List<ConfigConditional> conditionals;
     final private boolean resolved;
     final private boolean ignoresFallbacks;
 
     SimpleConfigObject(ConfigOrigin origin,
-            Map<String, AbstractConfigValue> value, ResolveStatus status,
-            boolean ignoresFallbacks) {
+            Map<String, AbstractConfigValue> value,
+            ResolveStatus status,
+            boolean ignoresFallbacks,
+            List<ConfigConditional> conditionals) {
         super(origin);
         if (value == null)
             throw new ConfigException.BugOrBroken(
@@ -41,6 +44,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
         this.value = value;
         this.resolved = status == ResolveStatus.RESOLVED;
         this.ignoresFallbacks = ignoresFallbacks;
+        this.conditionals = conditionals;
 
         // Kind of an expensive debug check. Comment out?
         if (status != ResolveStatus.fromValues(value.values()))
@@ -48,8 +52,21 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
     }
 
     SimpleConfigObject(ConfigOrigin origin,
+                       Map<String, AbstractConfigValue> value,
+                       ResolveStatus resolveStatus,
+                       boolean ignoresFallbacks) {
+        this(origin, value, resolveStatus, ignoresFallbacks, new ArrayList<ConfigConditional>());
+    }
+
+    SimpleConfigObject(ConfigOrigin origin,
             Map<String, AbstractConfigValue> value) {
-        this(origin, value, ResolveStatus.fromValues(value.values()), false /* ignoresFallbacks */);
+        this(origin, value, ResolveStatus.fromValues(value.values()), false /* ignoresFallbacks */, new ArrayList<ConfigConditional>());
+    }
+
+    SimpleConfigObject(ConfigOrigin origin,
+                       Map<String, AbstractConfigValue> value,
+                       List<ConfigConditional> conditionals) {
+        this(origin, value, ResolveStatus.fromValues(value.values()), false /* ignoresFallbacks */, conditionals);
     }
 
     @Override

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -418,8 +418,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
             for (ConfigConditional cond: this.conditionals) {
                 SimpleConfigObject body = cond.resolve(context, sourceWithParent);
                 AbstractConfigObject resolvedBody = body.resolveSubstitutions(context, source).value;
-//                if (resolvedBody != SimpleConfigObject.empty())
-                    value = value.mergedWithObject(resolvedBody);
+                value = value.mergedWithObject(resolvedBody);
             }
 
             return ResolveResult.make(modifier.context, value).asObjectResult();

--- a/config/src/test/resources/conditional.conf
+++ b/config/src/test/resources/conditional.conf
@@ -1,0 +1,14 @@
+shouldDoIt: true
+a: {
+  if [${shouldDoIt} == true] {
+    b: "b"
+    c: {
+      d: "d"
+    }
+  }
+  x: {
+    if [${shouldDoIt} == false] {
+    e: "e"
+  }
+  }
+}

--- a/config/src/test/resources/conditional.conf
+++ b/config/src/test/resources/conditional.conf
@@ -5,6 +5,7 @@ a: {
   }
   if [${shouldDoIt} == true] {
     c: "c"
+    f: ${a.b}
     nested: {
       n: "n"
       if [${a.c} == "c"] {

--- a/config/src/test/resources/conditional.conf
+++ b/config/src/test/resources/conditional.conf
@@ -2,13 +2,17 @@ shouldDoIt: true
 a: {
   if [${shouldDoIt} == true] {
     b: "b"
-    c: {
-      d: "d"
+  }
+  if [${shouldDoIt} == true] {
+    c: "c"
+    nested: {
+      n: "n"
+      if [${a.c} == "c"] {
+        works: true
+      }
     }
   }
-  x: {
-    if [${shouldDoIt} == false] {
-    e: "e"
-  }
+  if [${shouldDoIt} == false] {
+    d: "d"
   }
 }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -810,6 +810,18 @@ class ConfParserTest extends TestUtils {
     }
 
     @Test
+    def conditionals() {
+        val conf = ConfigFactory.parseResources("conditional.conf")
+        val resolved = conf.resolve()
+
+        assertEquals(resolved.getConfig("a").getString("b"), "b")
+        assertEquals(resolved.getConfig("a").getConfig("c").getString("d"), "d")
+        intercept[Exception] {
+            resolved.getConfig("a").getString("e")
+        }
+    }
+
+    @Test
     def acceptBOMStartingFile() {
         // BOM at start of file should be ignored
         val conf = ConfigFactory.parseResources("bom.conf")

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -815,9 +815,10 @@ class ConfParserTest extends TestUtils {
         val resolved = conf.resolve()
 
         assertEquals(resolved.getConfig("a").getString("b"), "b")
-        assertEquals(resolved.getConfig("a").getConfig("c").getString("d"), "d")
+        assertEquals(resolved.getConfig("a").getString("c"), "c")
+        assertEquals(resolved.getConfig("a").getConfig("nested").getBoolean("works"), true)
         intercept[Exception] {
-            resolved.getConfig("a").getString("e")
+            resolved.getConfig("a").getConfig("d")
         }
     }
 

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -816,6 +816,8 @@ class ConfParserTest extends TestUtils {
 
         assertEquals(resolved.getConfig("a").getString("b"), "b")
         assertEquals(resolved.getConfig("a").getString("c"), "c")
+        assertEquals(resolved.getConfig("a").getString("f"), "b")
+
         assertEquals(resolved.getConfig("a").getConfig("nested").getBoolean("works"), true)
         intercept[Exception] {
             resolved.getConfig("a").getConfig("d")

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentParserTest.scala
@@ -62,6 +62,7 @@ class ConfigDocumentParserTest extends TestUtils {
         parseTest("foo:bar")
         parseTest(" foo : bar ")
         parseTest("""include "foo.conf" """)
+        parseTest("if [${foo} == bar] { key: value }");
         parseTest("   \nfoo:bar\n    ")
 
         // Can parse a map with all simple types


### PR DESCRIPTION
Using the syntax of:

if [${subst} == string/bool] {
   body
}

If the expression evaluates to true, the body will be resolved and merged within the parent scope.

Current support equality checks against strings or booleans only.
