### PR TITLE
Allow key overrides in conditionals

### DIFF
--- a/config/src/main/java/com/twitter_typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/twitter_typesafe/config/impl/SimpleConfigObject.java
@@ -411,14 +411,15 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
         final ResolveSource sourceWithParent = source.pushParent(this);
 
         try {
+
             ResolveModifier modifier = new ResolveModifier(context, sourceWithParent);
 
             AbstractConfigValue value = modifyMayThrow(modifier);
 
             for (ConfigConditional cond: this.conditionals) {
                 SimpleConfigObject body = cond.resolve(context, sourceWithParent);
-                AbstractConfigObject resolvedBody = body.resolveSubstitutions(context, source).value;
-                value = value.mergedWithObject(resolvedBody);
+                AbstractConfigObject resolvedBody = body.resolveSubstitutions(context, sourceWithParent).value;
+                value = resolvedBody.withFallback(value);
             }
 
             return ResolveResult.make(modifier.context, value).asObjectResult();

--- a/config/src/test/resources/conditional.conf
+++ b/config/src/test/resources/conditional.conf
@@ -1,7 +1,10 @@
 shouldDoIt: true
+name: foo
 a: {
+  name: bar
   if [${shouldDoIt} == true] {
     b: "b"
+    name: baz
   }
   if [${shouldDoIt} == true] {
     c: "c"

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -817,6 +817,7 @@ class ConfParserTest extends TestUtils {
         assertEquals(resolved.getConfig("a").getString("b"), "b")
         assertEquals(resolved.getConfig("a").getString("c"), "c")
         assertEquals(resolved.getConfig("a").getString("f"), "b")
+        assertEquals(resolved.getConfig("a").getString("name"), "baz")
 
         assertEquals(resolved.getConfig("a").getConfig("nested").getBoolean("works"), true)
         intercept[Exception] {


### PR DESCRIPTION
Previous version was doing the merge backwards.

Expected:

{
  foo: bar
  if [${foo} == bar] { foo: baz }
}

should resolve to { foo: baz }.  Previously it was still foo: bar
